### PR TITLE
Re-rendering fixes for Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,8 +20,22 @@ environment:
 
   matrix:
     - TARGET_ARCH: x86
+      CONDA_PY: 27
 
     - TARGET_ARCH: x64
+      CONDA_PY: 27
+
+    - TARGET_ARCH: x86
+      CONDA_PY: 34
+
+    - TARGET_ARCH: x64
+      CONDA_PY: 34
+
+    - TARGET_ARCH: x86
+      CONDA_PY: 35
+
+    - TARGET_ARCH: x64
+      CONDA_PY: 35
 
 
 # We always use a 64-bit machine, but can build x86 distributions

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,6 @@ build:
 
 requirements:
   build:
-    - python         # [win]
     - curl           # [win]
     - 7za            # [win]
     - vc {{ VC_VERSION }}  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 1
+  number: 2
   detect_binary_files_with_prefix: true
   features:
     - vc{{ VC_VERSION }}   # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,6 +16,7 @@ build:
 
 requirements:
   build:
+    - python         # [win]
     - curl           # [win]
     - 7za            # [win]
     - vc {{ VC_VERSION }}  # [win]


### PR DESCRIPTION
Fixes some re-rendering issues that occurred in PR ( https://github.com/conda-forge/tk-feedstock/pull/5 ). Note this [line]( https://github.com/conda-forge/tk-feedstock/pull/5/files#diff-180360612c6b8c4ed830919bbb4dd459L22 ) and below. Also please note the comments that follow. The Windows packages from that build have been pulled.

Basically makes this work by temporarily adding `python` as a `build` dependency and removing it after re-rendering. Maybe a similar hack can be added to `conda-smithy` at a minimum.

Also bumps the build number for a fresh build on Windows.

cc @looooo @jjhelmus @pelson