### PR TITLE
Weird Windows hack for Re-rendering [ci skip]

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,3 +1,10 @@
+# Uncomment for Windows re-rendering only.
+#
+#matrix:
+#  - [[VC_VERSION, 9], [CONDA_PY, 27]]
+#  - [[VC_VERSION, 10], [CONDA_PY, 34]]
+#  - [[VC_VERSION, 14], [CONDA_PY, 35]]
+
 travis:
   secure:
     BINSTAR_TOKEN: GvyWsKD36Nv35v0qNpeNn0+0YYyDIvBTmEdxTuXCWjHFH3Ti977QXxs2hmVfM+Qch/tRokRANFSi5Gu7REjFH/5S/OPFdHX+Sk1P9zbsRN56ZrCkNaWg6quBDvSLboWCWB7xiGRPgIbxIuu6Z3Ob2Ej9+B2dKGt7vKu/ezvVv/BMdRygwM0IfFpvy182M10sVTx1/qvaWDBqmM/0Z/gIw+ZQ+S023Vhq2pGdwPG6sTPFTQoNSvtcUKy1MNTNCu+PS4iHRmtDN0zCGLdnZiaNUUEuwBmw3puqFemIhqcshrZpIXgFeGacqexCZy7D5L9BQZCpcuu4GqoEFamMXGyPn0vd712/Y1SEVbxg//zTHUJXDVW/DjNOJJg2eH0d0okd3qDZVMpYtqJ1bjADpfjTk1qOAB77S4g6dCtidj85RMRuEU1SzHfQYLNk9Rlww6uG7Ece2o3BKlk77njeeZUyTVw1aWnixw2PjAwpv2oCykSlfUh8YlVgQGnE3R0vi0C9DKo47PafxNiwf9FU7b9QNJQTbT3nDhjyZ/gGkxIpZhbqFTyX/z+j9DKfqnG+n8ujFUi5wNH1HiPmrDJaPGbYb1YxCFWjrLchk9QolVltuOEiG7j+CtfhuvIRFrZaIKt3dzpPdZ3eH5KxVfkNy/9L6LU9jeLfvnG6xa9cKGQEpDk=


### PR DESCRIPTION
Adds a weird Windows hack for re-rendering. Here we provide a few lines in `conda-forge.yml` that are left commented, but can be uncommented for Windows re-rendering only.

Basically my suggestion until we have something better is to do the following.

1. Re-render with this commented.
2. Commit all changes.
3. Uncomment matrix section.
4. Re-render again
5. Recomment this section.
6. Only commit `appveyor.yml` (possibly amending the last re-rendering commit).

This should get us a little closer to a stable process for doing this.