### PR TITLE
Don't include random X11 headers in the OSX package

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -34,7 +34,7 @@ make
 make install
 
 cd $PREFIX
-rm -rf man share
+rm -rf man share include/X11
 
 # Link binaries to non-versioned names to make them easier to find and use.
 ln -s "${PREFIX}/bin/tclsh${VER_ARR[0]}.${VER_ARR[1]}" "${PREFIX}/bin/tclsh"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 4
+  number: 5
   detect_binary_files_with_prefix: true
   features:
     - vc{{ VC_VERSION }}   # [win]


### PR DESCRIPTION
See issue #15. Build number bumped to 5.