### PR TITLE
WIP: Use conda-forge's X.org X11 headers

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -35,3 +35,16 @@ ln -s "${PREFIX}"/bin/wish${VER_ARR[0]}.${VER_ARR[1]} "${PREFIX}"/bin/wish
 
 # copy headers
 cp "${SRC_DIR}"/tk${PKG_VERSION}/{unix,generic}/*.h "${PREFIX}"/include/
+
+if [[ $(uname) == Darwin ]] ; then
+    # On macOS, we configure Tk to use the Aqua backend. Even when Tk uses a
+    # non-X11 backend, its header files still reference declarations from the
+    # X11 windowing system, so in those cases Tk installs its own dummy X11
+    # headers. However, on conda-forge we also provide the X.org X11 library
+    # stack, and the two sets of headers are not compatible. Therefore on
+    # macOS we delete those headers and list xorg-libx11 as a runtime
+    # dependency. Really it's a development-only dependency, but we don't
+    # (yet?) have a split between "main" and "devel" packages as seen in most
+    # Linux distros.
+    rm -rf "${PREFIX}"/include/X11/
+fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,6 +33,8 @@ requirements:
     - make                               # [linux]
   host:
     - zlib  # [unix]
+  run:
+    - xorg-libx11  # [osx] -- see comment at the bottom of build.sh for an explanation
 
 test:
 


### PR DESCRIPTION
The key motivation of this change is to prevent the OSX build of Tk from installing dummy X11 headers that prevent more sophisticated X11-based packages from being built on OSX. I'm not 100% that the commit in this submission does the right thing, but I need to see what happens when it's run through CI in order to find out.

This change also starts the process of decoupling conda-forge's packages from the system installation of X11, allowing us to be installed on more exotic systems that may not have X11 available as a system library.