### PR TITLE
Enable threads for tk 8.5

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -19,6 +19,7 @@ cd $SRC_DIR/tcl${VER}/unix
 ./configure \
 	--prefix="${PREFIX}" \
 	$ARCH_FLAG \
+	 --enable-threads \
 
 make
 make install
@@ -29,6 +30,7 @@ cd $SRC_DIR/tk${VER}/unix
 	$ARCH_FLAG \
 	--with-tcl="${PREFIX}/lib" \
 	--enable-aqua=yes \
+	--enable-threads \
 
 make
 make install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 1
+  number: 2
   detect_binary_files_with_prefix: true
   features:
     - vc{{ VC_VERSION }}   # [win]


### PR DESCRIPTION
We're working on packaging the [OOMMF software](http://math.nist.gov/oommf/), which benefits from threading in tcl/tk. Threads are apparently enabled by default in tk 8.6, but not 8.5. However, Python is built with tk 8.5, so we want to build OOMMF against that as well, so that it can be installed in a conda environment with Python.