### PR TITLE
Use VC matrix

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,8 +1,7 @@
-# Uncomment for Windows re-rendering only.
-#
-#matrix:
-#  - [[VC_VERSION, 9], [CONDA_PY, 27]]
-#  - [[VC_VERSION, 14], [CONDA_PY, 35]]
+matrix:
+  - []
+  - [[VC_VERSION, 9], [CONDA_PY, 27]]
+  - [[VC_VERSION, 14], [CONDA_PY, 35]]
 
 travis:
   secure:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set maj_min = ".".join(version.split(".")[:2]) %}
 {% set majmin = "".join(version.split(".")[:2]) %}
 
-{% set VC_VERSION = os.environ.get('VC_VERSION', '9')|string %}
+{% set VC_VERSION = os.environ.get("VC_VERSION", "")|string %}
 
 package:
   name: tk
@@ -11,6 +11,13 @@ package:
 build:
   number: 5
   detect_binary_files_with_prefix: true
+
+{% if VC_VERSION == "" %}
+  skip: true               # [win]
+{% elif VC_VERSION != "" %}
+  skip: true               # [unix]
+{% endif %}
+
   features:
     - vc{{ VC_VERSION }}   # [win]
 


### PR DESCRIPTION
Makes use of `skip` and Jinja to selectively apply the matrix from `conda-forge.yml` only to Windows. Leaves the other platforms unchanged. Thanks @inducer for the inspiration ( https://github.com/conda-forge/pyopencl-feedstock/pull/5 ).

~~Unfortunately the re-render seemed to have resorted the matrix in the `appveyor.yml` file. Though all entries are still present. Have raised `conda-smithy` issue ( https://github.com/conda-forge/conda-smithy/issues/537 ) to address this behavior.~~ Fixed by sticking with integers instead of strings.

All in all this should make it easier to re-render `tk` going forward without having to think about how it should work as much. Hopefully @jjhelmus appreciates the improvement. 😉