### PR TITLE
Install TCL private headers

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -28,7 +28,7 @@ jobs:
   # configure qemu binfmt-misc running.  This allows us to run docker containers 
   # embedded qemu-static
   - script: |
-      docker run --rm --privileged multiarch/qemu-user-static:register
+      docker run --rm --privileged multiarch/qemu-user-static:register --reset --credential yes
       ls /proc/sys/fs/binfmt_misc/
     condition: not(startsWith(variables['CONFIG'], 'linux_64'))
     displayName: Configure binfmt_misc

--- a/.azure-pipelines/build_steps.sh
+++ b/.azure-pipelines/build_steps.sh
@@ -15,7 +15,7 @@ export CONFIG_FILE="${CI_SUPPORT}/${CONFIG}.yaml"
 cat >~/.condarc <<CONDARC
 
 conda-build:
-  root-dir: /home/conda/feedstock_root/build_artifacts
+ root-dir: /home/conda/feedstock_root/build_artifacts
 
 CONDARC
 
@@ -25,6 +25,14 @@ conda install --yes --quiet conda-forge-ci-setup=2 conda-build -c conda-forge
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 run_conda_forge_build_setup
+
+# Install the yum requirements defined canonically in the
+# "recipe/yum_requirements.txt" file. After updating that file,
+# run "conda smithy rerender" and this line will be updated
+# automatically.
+/usr/bin/sudo -n yum install -y libX11-devel
+
+
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 

--- a/.azure-pipelines/run_docker_build.sh
+++ b/.azure-pipelines/run_docker_build.sh
@@ -38,39 +38,20 @@ DOCKER_IMAGE=$(cat "${FEEDSTOCK_ROOT}/.ci_support/${CONFIG}.yaml" | shyaml get-v
 mkdir -p "$ARTIFACTS"
 DONE_CANARY="$ARTIFACTS/conda-forge-build-done-${CONFIG}"
 rm -f "$DONE_CANARY"
-
-# Set up the docker image that we are going to use.  This is used to install yum requirements at build time if needed
-docker pull $DOCKER_IMAGE
-
-pushd ${RECIPE_ROOT}
-if [ -f ${RECIPE_ROOT}/yum_requirements.txt ]; then
-
-    cat >Dockerfile.yum <<DOCKERFILE
-FROM ${DOCKER_IMAGE}
-ADD yum_requirements.txt /opt/requirements.txt
-RUN yum -y install \$(cat /opt/requirements.txt)
-DOCKERFILE
-
-    export NEW_DOCKER_IMAGE="conda-smithy-$(openssl rand -hex 12)"
-    docker build -t ${NEW_DOCKER_IMAGE} --file Dockerfile.yum .
-    export DOCKER_IMAGE=$NEW_DOCKER_IMAGE
-    echo "Generated new image!"
-fi
-popd
 # Not all providers run with a real tty.  Disable using one
 DOCKER_RUN_ARGS=" "
 
 export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
 docker run ${DOCKER_RUN_ARGS} \
-    -v "${RECIPE_ROOT}":/home/conda/recipe_root:ro,z \
-    -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z \
-    -e CONFIG \
-    -e BINSTAR_TOKEN \
-    -e HOST_USER_ID \
-    -e UPLOAD_PACKAGES \
-    $DOCKER_IMAGE \
-    bash \
-    /home/conda/feedstock_root/${PROVIDER_DIR}/build_steps.sh
+           -v "${RECIPE_ROOT}":/home/conda/recipe_root:ro,z \
+           -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z \
+           -e CONFIG \
+           -e BINSTAR_TOKEN \
+           -e HOST_USER_ID \
+           -e UPLOAD_PACKAGES \
+           $DOCKER_IMAGE \
+           bash \
+           /home/conda/feedstock_root/${PROVIDER_DIR}/build_steps.sh
 
 # verify that the end of the script was reached
 test -f "$DONE_CANARY"

--- a/.circleci/build_steps.sh
+++ b/.circleci/build_steps.sh
@@ -15,7 +15,7 @@ export CONFIG_FILE="${CI_SUPPORT}/${CONFIG}.yaml"
 cat >~/.condarc <<CONDARC
 
 conda-build:
-  root-dir: /home/conda/feedstock_root/build_artifacts
+ root-dir: /home/conda/feedstock_root/build_artifacts
 
 CONDARC
 
@@ -25,6 +25,14 @@ conda install --yes --quiet conda-forge-ci-setup=2 conda-build -c conda-forge
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 source run_conda_forge_build_setup
+
+
+# Install the yum requirements defined canonically in the
+# "recipe/yum_requirements.txt" file. After updating that file,
+# run "conda smithy rerender" and this line will be updated
+# automatically.
+/usr/bin/sudo -n yum install -y libX11-devel
+
 
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/.circleci/run_docker_build.sh
+++ b/.circleci/run_docker_build.sh
@@ -38,39 +38,20 @@ DOCKER_IMAGE=$(cat "${FEEDSTOCK_ROOT}/.ci_support/${CONFIG}.yaml" | shyaml get-v
 mkdir -p "$ARTIFACTS"
 DONE_CANARY="$ARTIFACTS/conda-forge-build-done-${CONFIG}"
 rm -f "$DONE_CANARY"
-
-# Set up the docker image that we are going to use.  This is used to install yum requirements at build time if needed
-docker pull $DOCKER_IMAGE
-
-pushd ${RECIPE_ROOT}
-if [ -f ${RECIPE_ROOT}/yum_requirements.txt ]; then
-
-    cat >Dockerfile.yum <<DOCKERFILE
-FROM ${DOCKER_IMAGE}
-ADD yum_requirements.txt /opt/requirements.txt
-RUN yum -y install \$(cat /opt/requirements.txt)
-DOCKERFILE
-
-    export NEW_DOCKER_IMAGE="conda-smithy-$(openssl rand -hex 12)"
-    docker build -t ${NEW_DOCKER_IMAGE} --file Dockerfile.yum .
-    export DOCKER_IMAGE=$NEW_DOCKER_IMAGE
-    echo "Generated new image!"
-fi
-popd
 # Enable running in interactive mode attached to a tty
 DOCKER_RUN_ARGS=" -it "
 
 export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
 docker run ${DOCKER_RUN_ARGS} \
-    -v "${RECIPE_ROOT}":/home/conda/recipe_root:ro,z \
-    -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z \
-    -e CONFIG \
-    -e BINSTAR_TOKEN \
-    -e HOST_USER_ID \
-    -e UPLOAD_PACKAGES \
-    $DOCKER_IMAGE \
-    bash \
-    /home/conda/feedstock_root/${PROVIDER_DIR}/build_steps.sh
+           -v "${RECIPE_ROOT}":/home/conda/recipe_root:ro,z \
+           -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z \
+           -e CONFIG \
+           -e BINSTAR_TOKEN \
+           -e HOST_USER_ID \
+           -e UPLOAD_PACKAGES \
+           $DOCKER_IMAGE \
+           bash \
+           /home/conda/feedstock_root/${PROVIDER_DIR}/build_steps.sh
 
 # verify that the end of the script was reached
 test -f "$DONE_CANARY"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -13,7 +13,7 @@ pushd tcl${PKG_VERSION}/unix
                --host=${HOST}        \
                ${ARCH_FLAG}
   make -j${CPU_COUNT} ${VERBOSE_AT}
-  make install
+  make install install-private-headers
 popd
 
 pushd tk${PKG_VERSION}/unix

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     sha256: d3f9161e8ba0f107fe8d4df1f6d3a14c30cc3512dfc12a795daa367a27660dac
 
 build:
-  number: 1000
+  number: 1001
   detect_binary_files_with_prefix: true
   run_exports:
     # pin to major.minor because library names have that info in them


### PR DESCRIPTION
To be able to build Tcl extensions, the private header files should be packaged as well.