### PR TITLE
Remove buildroot references from {tcl,tk}Config.sh scripts

### DIFF
--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -3,7 +3,7 @@ BUILD:
 c_compiler:
 - gcc
 c_compiler_version:
-- '7'
+- '7.5'
 cdt_arch:
 - aarch64
 cdt_name:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -10,8 +10,6 @@ channel_targets:
 - conda-forge main
 macos_machine:
 - x86_64-apple-darwin13.4.0
-macos_min_version:
-- '10.9'
 pin_run_as_build:
   zlib:
     max_pin: x.x

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -10,8 +10,6 @@ channel_targets:
 - conda-forge main
 macos_machine:
 - arm64-apple-darwin20.0.0
-macos_min_version:
-- '11.0'
 pin_run_as_build:
   zlib:
     max_pin: x.x

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -35,3 +35,9 @@ ln -s "${PREFIX}"/bin/wish${VER_ARR[0]}.${VER_ARR[1]} "${PREFIX}"/bin/wish
 
 # copy headers
 cp "${SRC_DIR}"/tk${PKG_VERSION}/{unix,macosx,generic}/*.h "${PREFIX}"/include/
+
+# Remove buildroot traces
+sed -i.bak -e "s,${SRC_DIR}/tk${PKG_VERSION}/unix,${PREFIX}/lib,g" -e "s,${SRC_DIR}/tk${PKG_VERSION},${PREFIX}/include,g" ${PREFIX}/lib/tkConfig.sh
+sed -i.bak -e "s,${SRC_DIR}/tcl${PKG_VERSION}/unix,${PREFIX}/lib,g" -e "s,${SRC_DIR}/tcl${PKG_VERSION},${PREFIX}/include,g" ${PREFIX}/lib/tclConfig.sh
+rm -f ${PREFIX}/lib/tkConfig.sh.bak
+rm -f ${PREFIX}/lib/tclConfig.sh.bak

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     sha256: 63df418a859d0a463347f95ded5cd88a3dd3aaa1ceecaeee362194bc30f3e386
 
 build:
-  number: 0
+  number: 1
   detect_binary_files_with_prefix: true
   run_exports:
     # pin to major.minor because library names have that info in them

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -88,7 +88,7 @@ test:
 
 about:
   home: http://www.tcl.tk/
-  license: Tcl/Tk
+  license: TCL
   license_family: BSD
   license_file: tcl{{ version }}/license.terms
   summary: A dynamic programming language with GUI support.  Bundles Tcl and Tk.


### PR DESCRIPTION
Resolves https://github.com/conda-forge/tk-feedstock/issues/45
xref: https://src.fedoraproject.org/rpms/tk/blob/f32/f/tk.spec#_82

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
